### PR TITLE
perf(cli): use jemalloc to get faster research time with musl

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,3 +33,6 @@ serde_regex = "1.1"
 serde_yaml = "0.8"
 tokio = { version = "=1.20", features = ["fs", "io-util", "macros", "rt-multi-thread"] }
 toml = "0.5"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,6 +10,13 @@ use wakuchin::worker;
 use crate::app::App;
 use crate::hit::hit;
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 type Result<T> = anyhow::Result<T, Box<dyn std::error::Error>>;
 
 pub async fn run() -> Result<bool> {


### PR DESCRIPTION
Running compiled `wakuchin_cli` for `x86_64-unknown-linux-musl` with `-i 2000000 -r WKNCWKNC -t 2` on my machine:

```
Benchmark 1: ./wakuchin-jemalloc -i 2000000 -r WKNCWKNC -t 2
  Time (mean ± σ):     463.5 ms ±   6.6 ms    [User: 3553.5 ms, System: 43.9 ms]
  Range (min … max):   454.0 ms … 472.9 ms    10 runs
 
Benchmark 2: ./wakuchin-nojemalloc -i 2000000 -r WKNCWKNC -t 2
  Time (mean ± σ):      7.253 s ±  0.147 s    [User: 58.133 s, System: 35.767 s]
  Range (min … max):    6.954 s …  7.431 s    10 runs
```